### PR TITLE
Layout issue on transaction page

### DIFF
--- a/app/assets/stylesheets/pages/_transactions.scss
+++ b/app/assets/stylesheets/pages/_transactions.scss
@@ -21,7 +21,7 @@
   }
 
 @media (min-width: 1200px) {
-  .container-width {
-    width: 100vw;
+  #container-width {
+    width: 100vw !important;
   }
 }

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -1,4 +1,4 @@
-<div class="container container-width">
+<div class="container" id="container-width">
   <h3 class="text-center pt-3">Order confirmed!</h3>
 
   <div class="d-inline-flex flex-row justify-content-around" >


### PR DESCRIPTION
Have made '.container-width' an ID and !important in attempt to override bootstrap container's default width.